### PR TITLE
CK Command Mismatch override

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -2,11 +2,11 @@ Stats:
   Info:
     About: |-
       Du findest hier weitere Informationen darüber, welche Statistiken Keira sammelt:
-      
+
       Dieser Server hat Statistiken: `{{serverState}}`
       Deine Statistiken sind aktuell: `{{userState}}`
       Deine Statistik-Einträge (von allen Servern): `{{count}}`
-      
+
       **Diese Statistiken bestehen aus:**
         - Datum & Uhrzeit
         - Server ID
@@ -14,14 +14,14 @@ Stats:
         - Benutzer ID
         - Typ der Statistik (Aktion gesehen, Beispiele: Nachricht, dem Server beigetreten, Reaktion, Name des benutzten Befehls, etc)
         - Wenn es sich um einen Kiera-Befehl handelt, so wird nur der Name des Befehls, und ob dieser erfoglreich ausgeführt wurde, gespeichert.
-      
+
       **Diese Statistiken enthalten nicht:**
         - Nachrichteninhalt (nichts was sich im Nachrichteninhalt befindet, unter anderem Text, Bilder, Links, etc)
         - Nachricht ID
         - Der Antworteinhalt von irgendwelchen Befehlen
         - Benutzer oder Nicknahmen
         - Irgendetwas in Direktnachrichten, wo Kiera nicht vorhanden ist
-      
+
       **Über das Deaktivieren von Statistiken:**
         - Auf dem Benutzer-Level: Keine Statistiken werden gespeichert (beinhaltet sowohl Server wie auch Kanäle)
         - Auf dem Kanal-Level: Keine Statistiken zu diesem Kanal oder den Benutzern im Kanal werden gesammelt.
@@ -34,17 +34,17 @@ Stats:
     DeletionNoStats: Für diesen Raum sind keine Statistiken vorhanden!
     Disabled: |-
       Alle Statistiken wurden für diesem Raum **deaktiviert**.
-      
+
       - Wenn du möchtest, dass alle gespeicherten Statistiken gelöscht werden, die Keira in diesem Kanal bis heute gesammelt hat, dann verwende: `{{prefix}}stats delete channel`.
       - Die Deaktivierung führt nur dazu, dass keine neuen Statistiken in diesem Kanal gesammelt werden.
-      - Wenn Statistiken nur deaktiviert wurden und nicht gelöscht, 
+      - Wenn Statistiken nur deaktiviert wurden und nicht gelöscht,
       - The `{{prefix}}stats channel` command will now be disabled for this channel.
-      
+
       For more information about Statistics, see the `{{prefix}}stats about` command output.
     DisabledInfo: 'Für diesen Raum sind Statistiken auf Anfrage deaktiviert worden.'
     Enabled: |-
       Statistiken sind für diesen Raum ab jetzt **aktiviert**.
-      
+
       Um mehr Informationen über Statistiken zu erfahren, sieh dir die Ausgabe dieses Befehls an: `{{prefix}}stats about`.
   Server:
     DeletionCancelled: Löschung der Server Statistiken abgebrochen! Bestätigung nicht innerhalb von 60 Sekunden erhalten.
@@ -54,42 +54,42 @@ Stats:
     DeletionNoStats: Für diesen Server befinden sich keine Statistiken in der Datenbank!
     Disabled: |-
       Für diesen Server sind nun alle Statistiken **deaktiviert**.
-      
+
       -Wenn du alle aufgezeichneten Daten löschen möchtest, nutze den Befehl `{{prefix}}stats delete server`.
       -Das deaktivieren stoppt das Aufzeichnen von weiteren Daten.
-      -Wenn die server Statistiken nicht gelöscht werden, können die Statistiken möglicherweise aufgerufen werden. 
+      -Wenn die server Statistiken nicht gelöscht werden, können die Statistiken möglicherweise aufgerufen werden.
       -Der Befehl `{{prefix}}stats server` ist für diesen Server deaktiviert.
-      
-      
+
+
       Für mehr Informationen über Statistiken nutze bitte den Befehl `{{prefix}}stats about`
     DisabledInfo: 'Statistiken sind nun für diesen Server deaktiviert.'
     Enabled: |-
       Statistiken sind jetzt für diesen Server **aktiviert**
-      
+
       Für mehr Informationen nutze bitte den `{{prefix}}stats about` Befehl.
   User:
     Disabled: |-
       Alle Statistiken sind für deinen Account deaktiviert (Auf allen Servern auf denen Kiera anwesend ist).
-      
+
       -Wenn du alle aufgezeichneten Statistiken löschen möchtest, nutze den Befehl `{{prefix}}stats delete user`.
       -Wenn die Benutzer Statistiken nicht gelöscht werden, können die Statistiken möglicherweise aufgerufen werden.
       -Der Befehl `{{prefix}}stats user` ist  nun für deinen Benutzer deaktiviert.
       -Was mit diesem Befehl NICHT deaktiviert wird:
-        -Das persönliche Nutzen vom Kiera Audit Log kann für deinen Account welches du auf der Webseite https://kierabot.xyz (Deine Befehle, Fortschritt etc...) 
+        -Das persönliche Nutzen vom Kiera Audit Log kann für deinen Account welches du auf der Webseite https://kierabot.xyz (Deine Befehle, Fortschritt etc...)
       -Andere Befehle wir zum Beispiel Decision logs oder andere Statistiken
-      
-      
-      Für mehr informationen sieh in `{{prefix}}stats about` nach. 
+
+
+      Für mehr informationen sieh in `{{prefix}}stats about` nach.
     Enabled: |-
       Statistiken für diesen Benutzer sind wieder aktiviert (auf allen Servern auf denen Kiera anwesend ist).
-      
+
       Für mehr Informationen über Statistiken benutze bitte den `{{prefix}}stats about` Befehl
 Decision:
   Edit:
     AddedManager: |-
-      {{user}} wurde zu {{id}} als Manager hinzugefügt. 
-      
-      Manager sind in der Lage, alle Aktionen auf einer Decision roll wie der Autor auszuführen, mit der Ausnahme, sie alle zusammen zu löschen. Dazu gehört, dass er sie in jedem Webportal sehen und bearbeiten kann, als ob er sie erstellt hätte. 
+      {{user}} wurde zu {{id}} als Manager hinzugefügt.
+
+      Manager sind in der Lage, alle Aktionen auf einer Decision roll wie der Autor auszuführen, mit der Ausnahme, sie alle zusammen zu löschen. Dazu gehört, dass er sie in jedem Webportal sehen und bearbeiten kann, als ob er sie erstellt hätte.
     AllConsumedOutcomesReset: Alle Ergebnisse der decision roll wurden zurückgesetzt
     AllConsumedOutcomesResetTo: Alle verbrauchten Ergebnisse der decision roll wurden zurückgesetzt, und die Reset Zeit ist nun `{{value}}`
     CancelledResetAllConsumedFlags: Zurücksetzen der Decision roll abgebrochen! Antwort nicht innerhalb einer Minute erhalten.
@@ -140,7 +140,7 @@ ChastiKey:
             {{{cardsRemaining}}}
           {{/unless}}
         {{/unless}}
-        
+
       MainStats: |-
         {{#if showAvgRating}}Durchschnittliche Bewertung `{{avgRating}}` | # Ratings `{{ratings}}`{{/if}}
         Verschlossen für `{{lockedFor}}` Monate bis heute | `{{locksCompleted}}` beendete Locks
@@ -167,10 +167,10 @@ ChastiKey:
     # 1366`
     PreviouslyCompleted: Dein Account wurde bereits verifiziert! Wenn es damit irgendwelche Probleme gibt, melde dich bitte bei `Emma#1366`
     VerifyRequired: |-
-      Um diesen Befehl nutzen zu können, muss der Benutzer verifiziert sein. 
+      Um diesen Befehl nutzen zu können, muss der Benutzer verifiziert sein.
       Bitte benutze hierfür den Befehl:
       `!ck verify`
-      
+
       Wenn du dies in den letzten 15 Minuten gemacht hast, kannst du den Vorgang mit dem erneuten eingeben von `!ck verify` beschleunigen.
   # Ticker
   Ticker:
@@ -181,10 +181,10 @@ ChastiKey:
     KeyholderOrAboveRoleRequired: 'Hierfür wird die Keyholder-Rolle oder höher benötigt.'
     SelfLookupErrorOrNotFound: >-
       Die Suche konnte nicht abgeschlossen werden, einige mögliche Gründe dafür:
-      
-      In der ChastiKey App könnte die Option `Display username in public stats, lists and data?` auf No gestellt dein, oder vor kurzem auf nein umgestellt worden sein. 
-      
-      Dein ChastiKey account wurde nicht gefunden, oder ein Server Problem ist aufgetreten. 
+
+      In der ChastiKey App könnte die Option `Display username in public stats, lists and data?` auf No gestellt dein, oder vor kurzem auf nein umgestellt worden sein.
+
+      Dein ChastiKey account wurde nicht gefunden, oder ein Server Problem ist aufgetreten.
       Bitte schaue nach ob du hierzu in den Announcements auf dem ChastiKey Discord findest.
     UserLookupErrorOrNotFound: >-
       Die Abfrage konnte nicht ausgeführt werden! Mögliche Gründe hierfür sind:
@@ -227,7 +227,7 @@ Moderate:
     ReasonForMutePrompt: Was ist der Grund für diese Stummschaltung? Geben Sie Ihren Grund innerhalb der nächsten 5 Minuten in so viele Zeilen wie nötig ein (Bearbeiten wird nicht gespeichert) oder wenn Sie mit Ihrer Eingabe zufrieden sind, senden Sie eine einfache Nachricht mit `:end`
     RolesUnableToManage: |-
       Die folgenden Rollen können nicht von Kiera und diesem Befehl verwaltet werden: ```
-      
+
       {{untouchableRoles}}
       ```
   Error:
@@ -238,7 +238,7 @@ Moderate:
     EntryUnmute: |-
       :mute: **Entstummter Benutzer**
       ```
-      
+
       @{{username}}#{{discriminator}} id:{{id}}
         ## Gestummt: {{dateFormatted}}
         ## Gestummt von: {{mutedBy}}
@@ -257,40 +257,40 @@ Locale:
     - `Emma <gh: rileyIO, discord: emma#1366>`
   Description: |-
     Englisch ist die Standardsprache für Kiera.
-    
+
     {{contributors}}
-    
+
     Wenn du bei der Übersetzung helfen möchtest, und die Sprache fließend beherrschst, melde dich bitte bei `emma#1366` um Zugang zum Übersetzer zu erhalten: `https://kierabot.xyz/translate`
-    Nicht alle Sprachen sind aufgelistet, wenn du eine nicht vorhandene Sprache übersetzen möchtest, gib Emma bescheid und Sie fügt die Sprache hinzu. 
+    Nicht alle Sprachen sind aufgelistet, wenn du eine nicht vorhandene Sprache übersetzen möchtest, gib Emma bescheid und Sie fügt die Sprache hinzu.
   Error:
     DoesNotExist: |-
-      Der Code (`{{locale}}`) stimmt nicht mit den bestehenden überein. Versuche einen der folgenden zu nutzen. 
+      Der Code (`{{locale}}`) stimmt nicht mit den bestehenden überein. Versuche einen der folgenden zu nutzen.
       {{{locales}}}
     NoneSpecified: |-
-      Bitte wähle eine der folgenden verfügbaren Sprachen aus: 
+      Bitte wähle eine der folgenden verfügbaren Sprachen aus:
       {{{locales}}}
   Language: Deutsch
   Name: Deutsch
   Success:
     Set: |-
-      Sprache `{{locale}}` erfolgreich eingestellt! Alle Antworten (welche bisher übersetzt sind) erscheinen nun in Deutsch. 
-      
+      Sprache `{{locale}}` erfolgreich eingestellt! Alle Antworten (welche bisher übersetzt sind) erscheinen nun in Deutsch.
+
       {{contributors}}
-      
-      Wenn ihr beim übersetzen helfen möchtet, wendet euch bitte an @emma#1366 und teilt ihr die Sprache mit. 
+
+      Wenn ihr beim übersetzen helfen möchtet, wendet euch bitte an @emma#1366 und teilt ihr die Sprache mit.
       `https://kierabot.xyz/translate`
   ShortDescription: Interationales Englisch und Standard für Kiera.
 Admin:
   BotManualRestart: 'Bot startet in `{{seconds}}` neu.'
   CommandCategoriesList: >-
     Hier ist eine Übersicht darüber, wie viele Befehle sich unter welcher Kategorie befinden. Wenn du mehr über einen Befehl erfahren möchtest, wie etwa der Name um Beschränkungen zu setzen oder weitere Informationen abzufragen, nutze `{{prefix}}admin command category Fun`.
-    
+
     ```
     {{categories}}
     ```
   CommandCategoryCommands: >-
     Folgende Befehle befinden sich in der Kategorie "{{category}}":
-    
+
     ```
     {{commands}}
     ```
@@ -301,6 +301,10 @@ Generic:
   Error:
     CommandDisabledInChannel: Der `{{command}}` Befehl ist in diesem Raum nicht erlaubt.
     CommandExactMatchFailedFallback: 'Beispiele von Befehlen in der `{{prefix}}{{command}}` Gruppe:'
+    CommandExactMatchFailedFallbackCK: 'Unbekannter Befehl'
+    CommandExactMatchFailedFallbackCKBody: |-
+      Kiera hat deine Anfrage nicht verstanden.
+      Wenn du Hilfe brauchst oder eine Liste der möglichen Befehle suchst, Probier mal ``{{prefix}}ck help``
     CommandExactMatchFailedOptions: '***Tipp:** Du kannst:* `{{prefix}}help {{command}}` verwenden, Hier sind einige Beispiele, die diesen Befehl verwenden:'
     HelpCommandMissing: Leider ist für diesen Befehl noch kein Hilfstext verfügbar.
     Internal: Befehl aufgrund eines internen Problems nicht ausgeführt! Dies kann weitere Untersuchungen erfordern. Wenn Sie dabei Unterstützung benötigen, besuchen Sie bitte https://kierabot.xyz/support
@@ -471,22 +475,22 @@ Poll:
   New: |-
     Neue Umfrage ID:
       `{{id}}`
-    
+
     Die folgenden Paramter können modifiziert werden, um die Erstellung der Umfrage abzuschliessen:
       - public (Standard: true) **`true`** | **`false`** - Erlaubt es, die Umfrage auf der Webseite anzusehen
       - open (Default: true) **`true`** | **`false`** - Erlaubt es Benutzern, bei der Umfrage abzustimmen
       - question: `{{question}}`
-    
+
     Nutze die folgenden Befehle, um die Parameter von oben zu verändern:
       `{{prefix}}poll edit {{id}} open false`
       `{{prefix}}poll edit {{id}} public false`
       `{{prefix}}poll edit {{id}} title "Füge einen Titel hinzu"`
       `{{prefix}}poll edit {{id}} question "Der bearbeitete Text hier"`
       `{{prefix}}poll edit {{id}} footer "Füge einen Footer hinzu"`
-    
+
     Um die Umfrage zu starten nutze (dies zeigt die Nachricht an, auf welcher die Benutzer abstimmen können):
     `{{prefix}}poll start {{id}}`
-    
+
     Um die Umfrage zu stoppen nutze:
       `{{prefix}}poll stop {{id}}`
   Error:
@@ -495,14 +499,14 @@ Poll:
     PropertyNotFound: Die angegebene Umfrageeigenschaft wurde nicht gefunden.
     PropertyUpdated: |-
       Umfrage ID `{{id}}` Eigenschaft `{{property}}` aktualisiert!
-      
+
       **Von:** `{{from}}` 🡒 **Zu:** `{{to}}`
   Edit:
     OptionAdded: |-
       Diese Auswahl wurde hinzugefügt!
       Emoji: {{emoji}}
       Beschreibung: {{description}}
-      
+
       Um diese Auswahl zu benutzen benutze: "{{prefix}}
     OptionRemoved: Die Umfrageoption {{optionID}} wurde entfernt!
   Interaction:
@@ -514,18 +518,18 @@ System:
     :::::::::::::::::::::::::::::::::::::::::
     --------------> Kiera Bot <--------------
     :::::::::::::::::::::::::::::::::::::::::
-    
+
     Version: {{version}}
     Discord Bot: {{user}}
-    
+
     Localization Languages: {{langs}}
     Localization Strings: {{strings}}
-    
+
     API Routes: {{routes}}
     Commands: {{commands}}
     Guilds: {{guilds}}
     Users: {{users}}
-    
+
     Database Ping: {{ping}}ms
-    
+
     =========================================

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -13,7 +13,7 @@ Locale:
       - `Emma <gh: rileyIO, discord: emma#1366>`
   Error:
     DoesNotExist: |-
-      That locale code (`{{locale}}`) does not match any that are available for Kiera. Try one of the following: 
+      That locale code (`{{locale}}`) does not match any that are available for Kiera. Try one of the following:
       {{{locales}}}
     NoneSpecified: |-
       Please select one of the following available locales:
@@ -103,7 +103,7 @@ ChastiKey:
         {{#if isVerified}}Verified to {{{verifiedTo}}}{{/if}}
         ‏‏‎ ‎
       LockStats: |-
-        Keyholder **`{{#if isSelfLocked}}Self Locked{{else}}{{{keyholderName}}}{{/if}}`** Status `Locked` 
+        Keyholder **`{{#if isSelfLocked}}Self Locked{{else}}{{{keyholderName}}}{{/if}}`** Status `Locked`
         Locked `{{lockedTime}}`
         Total time frozen `{{totalTimeFrozen}}`
         {{#unless isFixed}}
@@ -117,7 +117,7 @@ ChastiKey:
         {{/if}}
         Details {{#if isCumulative}}Cumulative{{else}}Non-Cumulative{{/if}} regularity `{{regularity}}` with `{{turnsMade}}` turns made.
 
-        Cards Picked/Discarded (Last `{{discardPileLength}}`, Newest First): 
+        Cards Picked/Discarded (Last `{{discardPileLength}}`, Newest First):
         {{{discardPile}}}
 
         {{#unless isHidden}}
@@ -140,7 +140,7 @@ ChastiKey:
     FastForward: Your account has been verified! Some data may still take **up to 15 minutes** to be cached and fully accessable.
     PreviouslyCompleted: Your account has already been verified! If there are any issues with this please reachout to `emma#1366`
     VerifyRequired: |-
-      This command requires your account be verified with ChastiKey using the following command: 
+      This command requires your account be verified with ChastiKey using the following command:
       `{{prefix}}ck verify`
 
       If you just did this in the last 15 minutes or less, you can speed up some of the verification update process by running `{{prefix}}ck verify` again.
@@ -168,7 +168,7 @@ ChastiKey:
         **`5` Fanatical Lockee 1st color** {{{fanaticalLockeeX}}}
         `55` Fanatical Lockee 2nd color {{{fanaticalLockeeY}}}
         `555` Fanatical Lockee 3rd color {{{fanaticalLockeeZ}}}
-        
+
         `101` Novice Keyholder {{{noviceKeyholder}}}
         `102` Keyholder {{{keyholder}}}
         `103` Established Keyholder {{{establishedKeyholder}}}
@@ -392,7 +392,7 @@ Decision:
     SetModeOptions: |-
       Mode options available are:
       > `0` = Basic (No limiting enabled)
-      > `1` = Temporarily Consume 
+      > `1` = Temporarily Consume
           (Make sure to set in seconds the reset time, Example: {{prefix}}decision "id" consume reset 60`)
       > `2` = Consume
           (Once the outcome has been used it will be out of rotation unless the author resets, Reset using: {{prefix}}decision "id" consume reset`)
@@ -443,6 +443,10 @@ Generic:
   Error:
     CommandExactMatchFailedOptions: '***Hint:** You can type:* `{{prefix}}help {{command}}`, Here are some examples using this command:'
     CommandExactMatchFailedFallback: 'Examples of commands in the `{{prefix}}{{command}}` group:'
+    CommandExactMatchFailedFallbackCK: 'Command Mismatch'
+    CommandExactMatchFailedFallbackCKBody: |-
+      Kiera doesn''t understand your request...
+      If you need help or are looking for the list of commands, try ``{{prefix}}ck help``
     CommandDisabledInChannel: The command `{{command}}` is not allowed in this channel.
     HelpCommandMissing: Unfortunately there's no help text for this command yet.
     Internal: Failed to complete command due to an internal issue! This may require further investigation. If you need support on this please visit `https://kierabot.xyz/support`
@@ -538,7 +542,7 @@ Poll:
   Edit:
     OptionAdded: |-
       Poll option has been added!
-        Emoji: {{emoji}} 
+        Emoji: {{emoji}}
         Description: {{description}}
 
       To remove this option use: "{{prefix}}poll remove option {{id}} {{optionID}}"
@@ -664,18 +668,18 @@ System:
     :::::::::::::::::::::::::::::::::::::::::
     --------------> Kiera Bot <--------------
     :::::::::::::::::::::::::::::::::::::::::
-       
+
     Version: {{version}}
     Discord Bot: {{user}}
-       
+
     Localization Languages: {{langs}}
     Localization Strings: {{strings}}
-       
+
     API Routes: {{routes}}
     Commands: {{commands}}
     Guilds: {{guilds}}
     Users: {{users}}
-       
+
     Database Ping: {{ping}}ms
-       
+
     =========================================

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -1,12 +1,12 @@
 Stats:
   Info:
     About: |-
-      Hieronder vind je informatie over enige statistieken van Kiera: 
-      
+      Hieronder vind je informatie over enige statistieken van Kiera:
+
       Deze server heeft statistieken:  `{{serverState}}`
       Jouw statistieken: `{{userState}}`
       Jouw statistiek-aantal (van alle servers): `{{count}}`
-      
+
       **Deze statistieken bevatten:**
       - Datum en tijd
       - Server ID
@@ -14,19 +14,19 @@ Stats:
       - User ID
       -T ype van de statistiek (laatste actie, bijvoorbeeld: Bericht, Aangesloten bij de server, Reacties, De naam van het commando, enzovoort)
       - Als het een Kiera commando was, dan bevat het enkel het commando en het resultaat
-      
+
       **Deze statistieken bevatten geen:**
       - Berichttekst (niets dat in het bericht staat, zoals text, plaatjes, URL's, enzovoort)
       - Bericht-ID
       - Het resultaat van een commando
       - Gebruikersnamen of bijnamen
       - Alles in DM's, aangezien Kiera daar niet in kijkt.
-      
+
       **Wil je de statistieken uitschakelen?**
       - Voor de gebruiker: er worden geen statistieken meer bewaard (zie ook server en kanaal)
       - Voor het kanaal: er worden geen statistieken meer bewaard over het kanaal of de gebruikers in dat kanaal
-      - Voor de server: op heel de server worden geen statistieken meer bewaard (inclusief kanalen en gebruikers). 
-      
+      - Voor de server: op heel de server worden geen statistieken meer bewaard (inclusief kanalen en gebruikers).
+
   Channel:
     DeletionCancelled: Wissen statistieken van dit kanaal niet doorgevoerd. Antwoord niet ontvangen binnen 60 seconden.
     DeletionConfirm: Weet je zeker dat je alle statistieken van dit kanaal wilt wissen? Verzend dan **`yes`** binnen 60 seconden!
@@ -35,17 +35,17 @@ Stats:
     DeletionNoStats: Er zijn geen statistieken opgeslagen voor dit kanaal!
     Disabled: |-
       Alle statistieken voor dit kanaal zijn nu **uitgeschakeld**.
-      
+
       - Als je alle opgeslagen statistieken tot vandaag wilt wissen, voer dan dit commando uit: `{{prefix}}stats delete channel`.
       - Alleen uitschakelen werkt uitsluitend voor toekomstige gegevens
       - Als de kanaalstatistieken uitgeschakeld zijn, maar niet gewist, dan kunnen ze nog steeds voorkomen in de server of gebruikers-statistieken.
       - Het commando `{{prefix}}stats channel` is nu uitgeschakeld voor dit kanaal.
-      
-      Voor meer informatie over statistieken, gebruik `{{prefix}}stats about` 
+
+      Voor meer informatie over statistieken, gebruik `{{prefix}}stats about`
     DisabledInfo: 'De statistieken voor dit kanaal zijn op verzoek uitgeschakeld. (Let op: ze kunnen voorkomen in server- of gebruikers-statistieken totdat alle statistieken van dit kanaal zijn gewist)'
     Enabled: |-
-      Statistieken voor dit kanaal zijn nu **ingeschakeld**. 
-      
+      Statistieken voor dit kanaal zijn nu **ingeschakeld**.
+
       Voor meer informatie over statistieken, gebruik `{{prefix}}stats about`.
   Server:
     DeletionCancelled: Wissen statistieken van dit kanaal niet doorgevoerd. Antwoord niet ontvangen binnen 60 seconden.
@@ -55,22 +55,22 @@ Stats:
     DeletionNoStats: Er zijn geen statistieken opgeslagen voor deze server!
     Disabled: |-
       Alle statistieken voor deze server zijn nu **uitgeschakeld**
-      
+
       - Als je alle opgeslagen statistieken tot vandaag wilt wissen, voer dan dit commando uit: `{{prefix}}stats delete channel`.
       - Alleen uitschakelen werkt uitsluitend voor toekomstige gegevens
       - Als de kanaalstatistieken uitgeschakeld zijn, maar niet gewist, dan kunnen ze nog steeds voorkomen in de kanaal- of gebruikers-statistieken.
       - Het commando `{{prefix}}stats server` is nu uitgeschakeld.
-      
-      Voor meer informatie over statistieken, gebruik `{{prefix}}stats about` 
+
+      Voor meer informatie over statistieken, gebruik `{{prefix}}stats about`
     DisabledInfo: 'De statistieken van deze server zijn op verzoek uitgeschakeld. (Let op: ze kunnen voorkomen in kanaal- of gebruikers-statistieken totdat alle statistieken van dit kanaal zijn gewist)'
     Enabled: |-
-      Statistieken voor deze server zijn nu **ingeschakeld**. 
-      
+      Statistieken voor deze server zijn nu **ingeschakeld**.
+
       Voor meer informatie over statistieken, gebruik `{{prefix}}stats about`.
   User:
     Disabled: |-
       Alle statistieken voor je account zijn nu **uitgeschakeld** (voor alle servers waarop Kiera actief is)
-      
+
       - Als je alle opgeslagen statistieken tot vandaag wilt wissen, voer dan dit commando uit: `{{prefix}}stats delete user`.
       - Alleen uitschakelen werkt uitsluitend voor toekomstige gegevens
       - Als de kanaal statistieken uitgeschakeld zijn, maar niet gewist, dan kunnen ze nog steeds voorkomen in de totalen van de kanaal of server-statistieken.
@@ -78,11 +78,11 @@ Stats:
       - Wat is niet uitgeschakeld met dit commando:
       -  Je persoonlijke Kiera gebruikers audit log wat je voor jouw account kunt vinden op https://kierabot.xyz (de commando's die je hebt uitgevoerd, de resultaten hiervan, enzovoort)
       - Andere commando's zoals het "Decision log" of andere plekken waar het niet puur statistieken betreft.
-      
-      Voor meer informatie over statistieken, gebruik `{{prefix}}stats about` 
+
+      Voor meer informatie over statistieken, gebruik `{{prefix}}stats about`
     Enabled: |-
       De statistieken voor je account zijn weer ingeschakeld (op alle servers waar Kiera actief is)
-      
+
       Voor meer informatie over statistieken, gebruik het commando  `{{prefix}}stats about`.
 Decision:
   Edit:
@@ -107,9 +107,9 @@ Decision:
     RemovedManager: '{{user}} is verwijderd als manager van {{id}}.'
     SetConsumeReset: '''Decision consume'' reset is niet toegevoegd aan: {{value}}'
     SetModeOptions: |-
-      Beschikbare opties zijn: 
+      Beschikbare opties zijn:
       > `0` = Standaard (Geen limieten)
-      > `1` = Tijdelijk verwijderen 
+      > `1` = Tijdelijk verwijderen
       (Let erop dat de reset-tijd in seconden is, bijvoorbeeld {{prefix}}decision "id" consume reset 60`)
       > `2` = Verwijderen
       (Als een uitslag is geweest, dan wordt hij niet meer gebruikt totdat de eigenaar dit reset, je reset dit door:  {{prefix}}decision "id" consume reset`)
@@ -165,9 +165,9 @@ ChastiKey:
     # 1366`
     PreviouslyCompleted: Je account is al geverifieerd! Als er iets mis is, neem dan contact op met `emma.
     VerifyRequired: |-
-      Voor deze opdracht moet je account geverifieerd zijn met Chastikey. Gebruik hiervoor het volgende commando: 
+      Voor deze opdracht moet je account geverifieerd zijn met Chastikey. Gebruik hiervoor het volgende commando:
       `!ck verify`
-      
+
       Als je dit al hebt gedaan in de afgelopen 15 minuten, dan kun je de verificatie versnellen door `!ck verify` nogmaals uit te voeren
   # Ticker
   Ticker:
@@ -246,11 +246,11 @@ Locale:
     Deze vertaling is gemaakt door:
       - `HTuser <HTuser#28566> en Milady Eener <Milady Eener#1602>`
   Description: |-
-    
+
     "Nederlads.
-    
+
     {{contributors}}
-    
+
     Als je wilt helpen vertalen in een taal die je vloeiend spreekt, contact dan `emma#1366` om toegang te krijgen tot deze taal: `https://kierabot.xyz/translate` Niet alle talen staan hierin, als je een taal mist, laat het Emma weten en hij wordt toegevoegd"
   Error:
     DoesNotExist: |-
@@ -264,9 +264,9 @@ Locale:
   Success:
     Set: |-
       Landcode `{{locale}}` geselecteerd! Alle meldingen (die zijn vertaald) worden nu weergegeven in het Nederlands.
-      
+
       {{contributors}}
-      
+
       Als je wilt helpen bij deze vertaling, contact Emma#1366 en vraag om toegang op: `https://kierabot.xyz/translate`
   ShortDescription: Nederlandse taal
 Admin:
@@ -278,7 +278,7 @@ Admin:
     ```
   CommandCategoryCommands: >-
     De volgende commando's zijn beschikbaar in de categorie {{category}}:
-    
+
     ```
     {{commands}}
     ```
@@ -289,6 +289,10 @@ Generic:
   Error:
     CommandDisabledInChannel: Het commando  `{{command}}` is niet toegestaan in dit kanaal.
     CommandExactMatchFailedFallback: 'Voorbeelden van commando''s in de `{{prefix}}{{command}}` groep:'
+    CommandExactMatchFailedFallbackCK: 'Commando niet gevonden'
+    CommandExactMatchFailedFallbackCKBody: |-
+      Kiera kon dit commando niet vinden...
+      Voor een lijst van commandos, probeer ``{{prefix}}ck help``
     CommandExactMatchFailedOptions: '**Hint.** Het commando is:* `{{prefix}}help {{command}}`, hier een paar voorbeelden van dit commando: '
     HelpCommandMissing: Helaas is er nog geen helptekst beschikbaar voor dit commando
     Internal: Dit commando kan niet uitgevoerd worden door een intern probleem. Dit moet misschien uitgezocht worden. Heb je hier hulp bij nodig, bezoek dan `https://kierabot.xyz/support`
@@ -459,22 +463,22 @@ Poll:
   New: |-
     Nieuwe Poll ID:
       `{{id}}`
-    
+
     De volgende opties zijn beschikbaar om je poll aan te maken:
       - public (Default: true) **`true`** | **`false`** - Is de poll zichtbaar op de website of niet
       - open (Default: true) **`true`** | **`false`** - Of de user mag stemmen op de poll
       - question: `{{question}}`
-    
+
     Gebruik deze commando's om de bovenstaande opties te wijzigen:
       `{{prefix}}poll edit {{id}} open false`
       `{{prefix}}poll edit {{id}} public false`
       `{{prefix}}poll edit {{id}} title "Hier je titel"`
       `{{prefix}}poll edit {{id}} question "Hier je vraag"`
       `{{prefix}}poll edit {{id}} footer "Hier je eindtekst"`
-    
+
     Start de poll met (hiermee krijg je de tekst waarop mensen stemmen):
     `{{prefix}}poll start {{id}}`
-    
+
     Stop de poll met:
       `{{prefix}}poll stop {{id}}`
   Error:
@@ -483,7 +487,7 @@ Poll:
     PropertyNotFound: Deze poll optie bestaat niet!
     PropertyUpdated: |-
       Poll ID `{{id}}` property `{{property}}` geupdated!
-      
+
       **Van:** `{{from}}` 🡒 **Naar:** `{{to}}`
   Edit:
     OptionAdded: |-
@@ -500,19 +504,19 @@ System:
     :::::::::::::::::::::::::::::::::::::::::
     --------------> Kiera Bot <--------------
     :::::::::::::::::::::::::::::::::::::::::
-    
+
     Versie: {{version}}
     Discord robot: {{user}}
-    
+
     Aanwezige talen: {{langs}}
     Localization zinnen: {{strings}}
-    
+
     API Routes: {{routes}}
     Commando's: {{commands}}
     Servers: {{guilds}}
     Gebruikers: {{users}}
-    
+
     Database Ping: {{ping}}ms
-    
+
     =========================================
     Startup

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -217,6 +217,15 @@ export class CommandRouter {
         this.bot.Log.Router.log(`Router -> Failed to match '${message.content}' to a route - ending routing`)
         this.bot.BotMonitor.LiveStatistics.increment('commands-invalid')
 
+        // Overwrite the help menu for the `ck` command unless it is preceded by `help`
+        if (args[0] == 'ck' && !(args.length >= 2 && args[1].toLowerCase() === 'help')) {
+          await message.channel.send(fallbackHelp(
+            this.bot.Localization.$render(kieraUser.locale, 'Generic.Error.CommandExactMatchFailedFallbackCK'),
+            this.bot.Localization.$render(kieraUser.locale, 'Generic.Error.CommandExactMatchFailedFallbackCKBody', { prefix })
+          ));
+          return;
+        }
+
         // Provide some feedback about the failed command(s)
         var exampleUseOfCommand = this.bot.Localization.$render(kieraUser.locale, 'Generic.Error.CommandExactMatchFailedFallback', { command: args[0] })
         var examplesToAppend = ``


### PR DESCRIPTION
Implemented the Overwrite as described in:

![image](https://user-images.githubusercontent.com/10339043/103238267-712b4200-494a-11eb-972c-d804f39e9b31.png)

Current way to view the help menu is through ``[prefix]ck help``

[Sidenote]
For some reason my vscode decided to lint the entire `yml` file so a lot of tabs and spaces have been removed, although that should have no effect on the execution or performance of this pull request.

Translation Credits:
`EN`: Lucemans#2066
`NL`: Lucemans#2066
`DE`: DeltaEightOne#9517
`FR`: Not Modified