### PR TITLE
10.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 10.2.1
+
+## 🛠️ Fixes
+
+- Fixed: [#95](https://github.com/rileyio/kiera-bot/issues/95) A server's `commandGroups` in the DB is reset on Guild Change event.
+
+---
+
 ## 10.2.0
 
 ### 🛠️ Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 🛠️ Fixes
 
 - Fixed: [#95](https://github.com/rileyio/kiera-bot/issues/95) A server's `commandGroups` in the DB is reset on Guild Change event.
+- Fixed: [#90](#https://github.com/rileyio/kiera-bot/issues/90) CS Stats output showing inconsistent results compared to 3rd party's (KH).
 
 - Updated: Locale renderer to remove double newlines and replace with single newline.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fixed: [#95](https://github.com/rileyio/kiera-bot/issues/95) A server's `commandGroups` in the DB is reset on Guild Change event.
 
+- Updated: Locale renderer to remove double newlines and replace with single newline.
+
 ---
 
 ## 10.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## 10.2.1
 
-## 🛠️ Fixes
+### 🛠️ Fixes
 
 - Fixed: [#95](https://github.com/rileyio/kiera-bot/issues/95) A server's `commandGroups` in the DB is reset on Guild Change event.
 - Fixed: [#90](https://github.com/rileyio/kiera-bot/issues/90) CS Stats output showing inconsistent results compared to 3rd party's (KH).
 - Fixed: [#87](https://github.com/rileyio/kiera-bot/issues/87) Newly introduced (v10.2) management script not fully working due to names.
 
+### 🪄 Updates
 - Updated: Locale renderer to remove double newlines and replace with single newline.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ## 🛠️ Fixes
 
 - Fixed: [#95](https://github.com/rileyio/kiera-bot/issues/95) A server's `commandGroups` in the DB is reset on Guild Change event.
-- Fixed: [#90](#https://github.com/rileyio/kiera-bot/issues/90) CS Stats output showing inconsistent results compared to 3rd party's (KH).
+- Fixed: [#90](https://github.com/rileyio/kiera-bot/issues/90) CS Stats output showing inconsistent results compared to 3rd party's (KH).
+- Fixed: [#87](https://github.com/rileyio/kiera-bot/issues/87) Newly introduced (v10.2) management script not fully working due to names.
 
 - Updated: Locale renderer to remove double newlines and replace with single newline.
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./locales:/home/node/app/locales
       - ./src:/home/node/app/src
-    container_name: kiera_bot
+    container_name: kiera-bot
     restart: on-failure
     ports:
       - '127.0.0.1:8234:8234'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - ./locales:/home/node/app/locales
       - ./plugins:/home/node/app/plugins
       - ./src:/home/node/app/src
-    container_name: kiera_bot
+    container_name: kiera-bot
     ports:
       - '127.0.0.1:8234:8234'
     # expose:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -51,43 +51,6 @@ BattleNet:
   Error:
     CharacterNotFound: Character Not Found!
 
-ChastiSafe:
-  Stats:
-    User:
-      Title: |-
-        **{{username}}**
-      MainStats: |-
-        **ChastiSafe User Statistics**
-        {{#if hasLevels}}
-        Levels
-         ↳ {{#if chastityLevel}} Chastity `{{chastityLevel}}` {{/if}} {{#if bondageLevel}} ● Bondage `{{bondageLevel}}` {{/if}} {{#if taskLevel}} ● Task `{{taskLevel}}` {{/if}}
-        {{/if}}
-        {{#if hasLevel}}
-        Keyholder Levels
-         ↳ {{#if keyholderLevelChastity}} Chastity `{{keyholderLevelChastity}}` {{/if}} {{#if keyholderLevelBondage}} ● Bondage `{{keyholderLevelBondage}}` {{/if}} {{#if keyholderLevelTask}} ● Task `{{keyholderLevelTask}}` {{/if}}
-        {{/if}}
-        Ratings
-         ↳ Keyholder Avg `{{averageRatingAsKeyholder}}` ● Count `{{ratingsAsKeyholderCount}}`
-         ↳ Lockee Avg `{{averageRatingAsLockee}}` ● Count `{{ratingsAsLockeeCount}}`
-
-        {{#if hasActiveChastityLocks}}
-        **Active Locks**
-        {{#each chastityLocks}}
-          {{{this}}}
-          ───────────────
-        {{/each}}
-        {{/if}}
-
-        {{#if hasChastiKeyData}}
-        **ChastiKey (Legacy)**
-        Avg Keyholder Rating `{{#if hasKeyholderRatings}}{{averageKeyholderRating}}{{else}}n/a{{/if}}` ● # Ratings `{{noOfKeyholderRatings}}`
-        Avg Lockee Rating `{{#if hasLockeeRatings}}{{averageLockeeRating}}{{else}}n/a{{/if}}` ● # Ratings `{{numberOfLockeeRatings}}`
-        Locked for `{{cumulativeSecondsLocked}}` months to date ● `{{numberOfCompletedLocks}}` locks completed
-        Longest (completed) `{{longestLockCompleted}}`
-        Average Time Locked (overall) `{{averageTimeLocked}}`
-        Date First Keyheld `{{keyheldStartTimestamp}}`
-        Joined `{{joinTimestamp}}` (`{{joinedDaysAgo}}` days ago)
-        {{/if}}
 
 Help:
   Admin:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kiera-bot",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "main": "app/index.js",
   "repository": "https://github.com/rileyio/kiera-bot.git",
   "author": "Emma (RileyIO)",

--- a/src/commands/chastisafe/user.embed.ts
+++ b/src/commands/chastisafe/user.embed.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sort-keys */
 import * as Utils from '@/utils'
 
 import { ChastiSafeUser } from '@/objects/chastisafe'
@@ -5,52 +6,103 @@ import { EmbedBuilder } from 'discord.js'
 import { Routed } from '@/router'
 
 export function embed(user: ChastiSafeUser, routed: Routed<'discord-chat-interaction'>) {
-  const description = routed.$render(
-    'ChastiSafe.Stats.User.MainStats',
-    Object.assign(
-      {
-        averageRatingAsKeyholder: user.ratings.averageRatingAsKeyholder || '--',
-        averageRatingAsLockee: user.ratings.averageRatingAsLockee || '--',
-        bondageLevel: user.levels.bondageLevel ? user.levels.bondageLevel : null,
-        chastityLevel: user.levels.chastityLevel ? user.levels.chastityLevel : null,
-        chastityLocks: user.lockInfo.chastityLocks.map(l => `🔒 **${l.lockName}**\n**Keyholder:** \`${l.keyholder}\`\n**Loaded:** \`${l.loadtime}\``),
-        hasActiveChastityLocks: user.lockInfo.chastityLocks.length > 0,
-        hasChastiKeyData: user.hasChastiKeyData,
-        hasKeyholderLevels: user.keyholderLevels.bondageLevel || user.keyholderLevels.chastityLevel || user.keyholderLevels.taskLevel,
-        hasLevels: user.levels.bondageLevel || user.levels.chastityLevel || user.levels.taskLevel,
-        keyholderLevelBondage: user.keyholderLevels.bondageLevel ? user.keyholderLevels.bondageLevel : null,
-        keyholderLevelChastity: user.keyholderLevels.chastityLevel ? user.keyholderLevels.chastityLevel : null,
-        keyholderLevelTask: user.keyholderLevels.taskLevel ? user.keyholderLevels.taskLevel : null,
-        ratingsAsKeyholderCount: user.ratings.ratingsAsKeyholderCount,
-        ratingsAsLockeeCount: user.ratings.ratingsAsLockeeCount,
-        taskLevel: user.levels.taskLevel ? user.levels.taskLevel : null
-      },
-      // Only include this if ChastiKey data is available
-      user.hasChastiKeyData
-        ? {
-            averageKeyholderRating: user.chastikeystats.averageKeyholderRating,
-            averageLockeeRating: user.chastikeystats.averageLockeeRating,
-            averageTimeLocked: Utils.Date.calculateHumanTimeDDHHMM(user.chastikeystats.averageTimeLockedInSeconds),
-            cumulativeSecondsLocked: Math.round((user.chastikeystats.cumulativeSecondsLocked / 2592000) * 100) / 100,
-            hasKeyholderRatings: user.chastikeystats.averageKeyholderRating !== 0,
-            hasLockeeRatings: user.chastikeystats.averageLockeeRating > 0,
-            hasManagedLocks: user.chastikeystats.totalLocksManaged > 0,
-            joinTimestamp: user.chastikeystats.joinTimestamp.substring(0, 10),
-            joinedDaysAgo: `${Math.round((Date.now() - new Date(user.chastikeystats.joinTimestamp).getTime()) / 1000 / 60 / 60 / 24)}`,
-            keyheldStartTimestamp: user.chastikeystats.keyheldStartTimestamp ? user.chastikeystats.keyheldStartTimestamp.substring(0, 10) : 'n/a',
-            longestLockCompleted: Utils.Date.calculateHumanTimeDDHHMM(user.chastikeystats.longestCompletedLockInSeconds),
-            noOfKeyholderRatings: user.chastikeystats.noOfKeyholderRatings,
-            numberOfCompletedLocks: user.chastikeystats.numberOfCompletedLocks,
-            numberOfLockeeRatings: user.chastikeystats.numberOfLockeeRatings,
-            totalLocksManaged: user.chastikeystats.totalLocksManaged
-          }
-        : {}
-    )
+  const data = Object.assign(
+    {
+      averageRatingAsKeyholder: user.ratings.averageRatingAsKeyholder || '--',
+      averageRatingAsLockee: user.ratings.averageRatingAsLockee || '--',
+      chastityLocks: user.lockInfo.chastityLocks.map((l) => `🔒 **${l.lockName}**\n**Keyholder:** \`${l.keyholder}\`\n**Loaded:** \`${l.loadtime}\``),
+      hasActiveChastityLocks: user.lockInfo.chastityLocks.length > 0,
+      hasChastiKeyData: user.hasChastiKeyData,
+      // Do they have any levels or kh counts (categories)
+      hasKeyholderLevels: user.keyholderLockCounts?.BONDAGE || user.keyholderLockCounts?.CHASTITY || user.keyholderLockCounts?.TASK,
+      hasLevels: user.keyholderLockCounts?.BONDAGE || user.keyholderLockCounts?.CHASTITY || user.keyholderLockCounts?.TASK,
+      hasRatings: user.ratings.averageRatingAsKeyholder || user.ratings.averageRatingAsLockee,
+      // Lockee Level Values (strings)
+      lockeeLevelBondage: user.levels.bondageLevel ? user.levels.bondageLevel : null,
+      lockeeLevelChastity: user.levels.chastityLevel ? user.levels.chastityLevel : null,
+      lockeeLevelTask: user.levels.taskLevel ? user.levels.taskLevel : null,
+      // Lockee Levels (boolean)
+      hasLockeeLevelBondage: 'bondageLevel' in user.levels,
+      hasLockeeLevelChastity: 'chastityLevel' in user.levels,
+      hasLockeeLevelTask: 'taskLevel' in user.levels,
+      // KH Level Values (strings)
+      keyholderLevelBondage: user.keyholderLevels.bondageLevel ? user.keyholderLevels.bondageLevel : null,
+      keyholderLevelChastity: user.keyholderLevels.chastityLevel ? user.keyholderLevels.chastityLevel : null,
+      keyholderLevelTask: user.keyholderLevels.taskLevel ? user.keyholderLevels.taskLevel : null,
+      // KH Levels (boolean)
+      hasKeyholderLevelBondage: !!user.keyholderLockCounts?.BONDAGE,
+      hasKeyholderLevelChastity: !!user.keyholderLockCounts?.CHASTITY,
+      hasKeyholderLevelTask: !!user.keyholderLockCounts?.TASK,
+      // Ratings counts
+      ratingsAsKeyholderCount: user.ratings.ratingsAsKeyholderCount,
+      ratingsAsLockeeCount: user.ratings.ratingsAsLockeeCount
+    },
+    // Only include this if ChastiKey data is available
+    user.hasChastiKeyData
+      ? {
+          averageKeyholderRating: user.chastikeystats.averageKeyholderRating,
+          averageLockeeRating: user.chastikeystats.averageLockeeRating,
+          averageTimeLocked: Utils.Date.calculateHumanTimeDDHHMM(user.chastikeystats.averageTimeLockedInSeconds),
+          cumulativeSecondsLocked: Math.round((user.chastikeystats.cumulativeSecondsLocked / 2592000) * 100) / 100,
+          hasKeyholderRatings: user.chastikeystats.averageKeyholderRating !== 0,
+          hasLockeeRatings: user.chastikeystats.averageLockeeRating > 0,
+          hasManagedLocks: user.chastikeystats.totalLocksManaged > 0,
+          joinTimestamp: user.chastikeystats.joinTimestamp.substring(0, 10),
+          joinedDaysAgo: `${Math.round((Date.now() - new Date(user.chastikeystats.joinTimestamp).getTime()) / 1000 / 60 / 60 / 24)}`,
+          keyheldStartTimestamp: user.chastikeystats.keyheldStartTimestamp ? user.chastikeystats.keyheldStartTimestamp.substring(0, 10) : 'n/a',
+          longestLockCompleted: Utils.Date.calculateHumanTimeDDHHMM(user.chastikeystats.longestCompletedLockInSeconds),
+          noOfKeyholderRatings: user.chastikeystats.noOfKeyholderRatings,
+          numberOfCompletedLocks: user.chastikeystats.numberOfCompletedLocks,
+          numberOfLockeeRatings: user.chastikeystats.numberOfLockeeRatings,
+          totalLocksManaged: user.chastikeystats.totalLocksManaged
+        }
+      : {}
   )
+
+  let body = `**ChastiSafe User Statistics**`
+
+  if (data.hasLevels) {
+    body += '\n\n **Lockee Levels**'
+    if (data.hasLockeeLevelBondage) body += `\n● ${data.lockeeLevelBondage || ''} Bondage`
+    if (data.hasLockeeLevelChastity) body += `\n● ${data.lockeeLevelChastity || ''} Chastity`
+    if (data.hasLockeeLevelTask) body += `\n● ${data.lockeeLevelTask || ''} Task`
+  }
+
+  if (data.hasKeyholderLevels) {
+    body += '\n\n**Keyholder Levels**'
+    if (data.hasKeyholderLevelBondage) body += `\n● ${data.keyholderLevelBondage || ''} Keyholder`
+    if (data.hasKeyholderLevelChastity) body += `\n● ${data.keyholderLevelChastity || ''} Bondage Puppeteer`
+    if (data.hasKeyholderLevelTask) body += `\n● ${data.keyholderLevelTask || ''} Task Director`
+  }
+
+  if (data.hasRatings) {
+    body += '\n\n**Ratings**'
+    if (data.ratingsAsKeyholderCount > 0) body += `\nKeyholder Avg \`${data.averageRatingAsKeyholder}\` | Count \`${data.ratingsAsKeyholderCount}\``
+    if (data.ratingsAsLockeeCount > 0) body += `\nLockee Avg \`${data.averageRatingAsLockee}\` | Count \`${data.ratingsAsLockeeCount}\``
+  }
+
+  if (data.hasActiveChastityLocks) {
+    body += '\n\n**Active Locks**'
+    data.chastityLocks.forEach((lock) => {
+      body += `\n${lock}`
+      body += '\n───────────────'
+    })
+  }
+
+  if (data.hasChastiKeyData) {
+    body += '\n\n**ChastiKey (Legacy)**'
+    body += `\nAvg Keyholder Rating \`${data.hasKeyholderRatings ? data.averageKeyholderRating : '--'}\` ● # Ratings \`${data.noOfKeyholderRatings}\``
+    body += `\nAvg Lockee Rating \`${data.hasLockeeRatings ? data.averageLockeeRating : '--'}\` ● # Ratings \`${data.numberOfLockeeRatings}\``
+    body += `\nLocked for \`${data.cumulativeSecondsLocked}\` months to date ● \`${data.numberOfCompletedLocks}\` locks completed`
+    body += `\nLongest (completed) \`${data.longestLockCompleted}\``
+    body += `\nAverage Time Locked (overall) \`${data.averageTimeLocked}\``
+    body += `\nDate First Keyheld \`${data.keyheldStartTimestamp}\``
+    body += `\nJoined \`${data.joinTimestamp}\``
+  }
 
   return new EmbedBuilder()
     .setColor(9125611)
-    .setDescription(description)
+    .setDescription(body)
     .setFooter({
       iconURL: 'https://cdn.discordapp.com/app-icons/526039977247899649/41251d23f9bea07f51e895bc3c5c0b6d.png',
       text: `Runtime ${routed.routerStats.performance}ms :: Requested By ${routed.routerStats.user} :: Retrieved by Kiera`

--- a/src/commands/chastisafe/user.embed.ts
+++ b/src/commands/chastisafe/user.embed.ts
@@ -107,11 +107,6 @@ export function embed(user: ChastiSafeUser, routed: Routed<'discord-chat-interac
       iconURL: 'https://cdn.discordapp.com/app-icons/526039977247899649/41251d23f9bea07f51e895bc3c5c0b6d.png',
       text: `Runtime ${routed.routerStats.performance}ms :: Requested By ${routed.routerStats.user} :: Retrieved by Kiera`
     })
-    .setTitle(
-      routed.$render('ChastiSafe.Stats.User.Title', {
-        username: user.user,
-        verifiedEmoji: '<:verified:625628727820288000> '
-      })
-    )
+    .setTitle(`**${user.user}**`)
     .setTimestamp(Date.now())
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,7 +300,6 @@ export class Bot {
 
   private async onGuildUpdate(old: Discord.Guild, changed: Discord.Guild) {
     this.Log.Bot.log(`Server Update Detected: id: ${old.id}, name: ${changed.name}`)
-    console.log(old, changed)
 
     // Save some info about the server in db
     await this.DB.update(

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ export class Bot {
     ///Server connect/disconnect///
     this.client.on('guildCreate', async (guild) => this.onGuildCreate(guild))
     this.client.on('guildDelete', async (guild) => this.onGuildDelete(guild))
-    this.client.on('guildUpdate', async (guild) => this.onGuildCreate(guild))
+    this.client.on('guildUpdate', async (old: Discord.Guild, changed: Discord.Guild) => this.onGuildUpdate(old, changed))
     this.client.on('guildMemberAdd', (member) => this.onUserJoined(member))
     this.client.on('guildMemberRemove', (member) => this.onUserLeft(member))
 
@@ -278,19 +278,41 @@ export class Bot {
   }
 
   private async onGuildCreate(guild: Discord.Guild) {
-    this.Log.Bot.log('Joined a new server: ' + guild.name)
+    this.Log.Bot.log(`Joined a new server: id: ${guild.id}, name: ${guild.name}`)
+
     // Save some info about the server in db
     await this.DB.update(
       'servers',
       { id: guild.id },
       {
         $set: new StoredServer({
-          commandGroups: {},
           id: guild.id,
           joinedTimestamp: guild.joinedTimestamp,
           lastSeen: Date.now(),
           name: guild.name,
           ownerID: guild.ownerId,
+          type: 'discord'
+        })
+      },
+      { atomic: true, upsert: true }
+    )
+  }
+
+  private async onGuildUpdate(old: Discord.Guild, changed: Discord.Guild) {
+    this.Log.Bot.log(`Server Update Detected: id: ${old.id}, name: ${changed.name}`)
+    console.log(old, changed)
+
+    // Save some info about the server in db
+    await this.DB.update(
+      'servers',
+      { id: old.id },
+      {
+        $set: new StoredServer({
+          id: old.id,
+          joinedTimestamp: old.joinedTimestamp,
+          lastSeen: Date.now(),
+          name: changed.name,
+          ownerID: changed.ownerId,
           type: 'discord'
         })
       },

--- a/src/localization.ts
+++ b/src/localization.ts
@@ -141,7 +141,7 @@ export default class Localization {
       // Check if string is translated - if not: fallback
       if (targetString) {
         const templ = Handlebars.compile(targetString, data as T | object)
-        return templ(data)
+        return templ(data).replace(/([\n]{2})/g, `\n`)
       }
     }
 
@@ -149,7 +149,7 @@ export default class Localization {
     if (typeof data === 'boolean' && data === false) return
     // Fallback
     const templ = Handlebars.compile(get(this.loaded[DEFAULT_LOCALE].strings, key))
-    return templ(data)
+    return templ(data).replace(/([\n]{2})/g, `\n`)
   }
 
   /**

--- a/src/objects/chastisafe.ts
+++ b/src/objects/chastisafe.ts
@@ -14,6 +14,7 @@ export enum ChastiSafeUserLockeeLevelsEnum {
   'Devoted',
   'Fanatical'
 }
+
 export class ChastiSafeUser {
   public badges: Array<'LOCKTOBER_ONGOING' | 'LOCKTOBER_2022' | 'LOCKTOBER_2022_SELF' | 'LOCKTOBER_ONGOING_SELF'> = []
 


### PR DESCRIPTION
# Change Log

### 🛠️ Fixes

- Fixed: [#95](https://github.com/rileyio/kiera-bot/issues/95) A server's `commandGroups` in the DB is reset on Guild Change event.
- Fixed: [#90](https://github.com/rileyio/kiera-bot/issues/90) CS Stats output showing inconsistent results compared to 3rd party's (KH).
- Fixed: [#87](https://github.com/rileyio/kiera-bot/issues/87) Newly introduced (v10.2) management script not fully working due to names.

### 🪄 Updates

- Updated: Locale renderer to remove double newlines and replace with single newline.